### PR TITLE
Bh responseatloc

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TMItransient"
 uuid = "ab8155c7-aa61-46aa-9e27-6244078cebd2"
 authors = ["G Jake Gebbie <ggebbie@whoi.edu>"]
-version = "0.1.6"
+version = "0.1.7"
 
 [deps]
 DelimitedFiles = "8bb1440f-4735-579b-a4ab-409b98df4dab"

--- a/src/TMItransient.jl
+++ b/src/TMItransient.jl
@@ -580,7 +580,6 @@ function globalmean_stepresponse(TMIversion,region,γ,L,B,τ)
 
     solfld = zeros(γ)
     for (u,t) in TimeChoiceIterator(integrator,τ)
-        @show t 
         solfld.tracer[wet(solfld)] = u
         push!(Dmean,mean(solfld))
     end

--- a/src/TMItransient.jl
+++ b/src/TMItransient.jl
@@ -543,9 +543,8 @@ function stepresponse(TMIversion, b, γ, L, B, τ; eval_func = return_self, args
     
     solfld = zeros(γ) #initialize solution Field 
     
-    for (u, t) in TimeChoiceIterator(integrator, τ)
+    for (idx, (u, t)) in enumerate(TimeChoiceIterator(integrator, τ))
         solfld.tracer[wet(solfld)] = u
-        idx = first(findall(x->x==t, τ)) #is this worse than a push?
         output[idx] = isempty(args) ? eval_func(solfld) : eval_func(solfld, args...)
     end
     return output

--- a/src/TMItransient.jl
+++ b/src/TMItransient.jl
@@ -16,7 +16,7 @@ export readopt, ces_ncwrite, varying!,
     deltaresponse, taudeltaresponse, agedistribution,
     EvolvingField,
     globalmean_stepresponse,
-    globalmean_impulseresponse
+    globalmean_impulseresponse, stepresponse
 
 """
     struct EvolvingField
@@ -508,6 +508,58 @@ function stability_check(sol_array, Csfc)
     println("stable: " *string(stable))
 end
 
+"""
+    function stepresponse
+
+    calculate the response to "turning on" some region
+    can compute some statistics on output by providing a function to f 
+
+    # Arguments
+    - TMIversion
+    - b: BoundaryCondition
+    - γ
+    - L
+    - B
+    - τ: evenly spaced vector
+    - f: some function f(u) where u is a vector of all wet points 
+"""
+function stepresponse(TMIversion, b, γ, L, B, τ; eval_func = return_self)
+    
+    # assume evenly spaced (uniform) time spacing
+    Δτ = diff(τ)[1]
+    #b = TMI.surfaceregion(TMIversion,region,γ)
+    c₀ = zeros(γ) # preallocate initial condition Field
+    c₀ = B* vec(b)
+    f(du,u,p,t) = mul!(du, L, u) #avoid allocation
+    func = ODEFunction(f, jac_prototype = L) #jac_prototype for sparse array
+    tspan = (first(τ), last(τ))
+    prob = ODEProblem(func, c₀, tspan) #Field type
+
+    # possible algs:
+    # QNDF, TRBDF2, FBDF, CVODE_BDF, lsoda, ImplicitEuler
+    integrator = init(prob,QNDF())
+    
+    #assumes `f` returns one output!
+    output = Vector{first(Base.return_types(eval_func, (Vector{Float64},)))}(undef, length(τ))
+    
+    solfld = zeros(γ) #initialize solution field
+    
+    for (u, t) in TimeChoiceIterator(integrator, τ)
+        solfld.tracer[wet(solfld)] = u
+        idx = first(findall(x->x==t, τ)) #is this worse than a push?
+        output[idx] = eval_func(solfld)
+    end
+    return output
+        
+end
+
+return_self(x) = x 
+
+"""
+function globalmean_stepresponse
+
+    calculate the global mean response to "turning on" some region
+"""
 function globalmean_stepresponse(TMIversion,region,γ,L,B,τ)
 
     # assume evenly spaced (uniform) time spacing
@@ -529,6 +581,7 @@ function globalmean_stepresponse(TMIversion,region,γ,L,B,τ)
 
     solfld = zeros(γ)
     for (u,t) in TimeChoiceIterator(integrator,τ)
+        @show t 
         solfld.tracer[wet(solfld)] = u
         push!(Dmean,mean(solfld))
     end
@@ -549,6 +602,13 @@ end
     Does leapfrog satisfy normalization?
 """
 globalmean_impulseresponse(TMIversion,region,γ,L,B,τ;alg=:centered) = globalmean_impulseresponse(globalmean_stepresponse(TMIversion,region,γ,L,B,τ),τ,alg=alg)
+
+"""
+    function globalmean_impulseresponse
+
+    based on a globalmean_stepresponse D̄, compute the impulse response
+    can be done via centered or leapfrog difference 
+"""
 function globalmean_impulseresponse(D̄,τ;alg=:centered)
     if alg == :centered
         ihi = 2:length(D̄)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -93,7 +93,7 @@ using Statistics
         @time D̄_old = globalmean_stepresponse(TMIversion,region,γ,L,B,τ) # CDF
 
         #D̄[1] won't match because original method sets it to 0 and I don't 
-        @test sum(D̄_new[2:3] .== D̄_old[2:3]) == 2 #105
+        @test sum(D̄_new[2:3] .== D̄_old[2:3]) == 2 # 105
 
         #get output in Field type 
         @time D̄_new_allout = stepresponse(TMIversion, b, γ, L, B, τ) #103s
@@ -125,7 +125,7 @@ using Statistics
         ḡ = hcat(Ḡ_long...)
         #d̄ = hcat(D̄_long...)
 
-        ā = [cumsum(ḡ[i, :] .* τ)[end] for i in 1:10]
+        ā = [cumsum(ḡ[i, :] .* τ)[end] for i in 1:2]
         #@test isapprox([cumsum(ḡ[i, :] .* τ)[end] for i in 1:10], meanage_obs, atol = 50)
 
         atol = 10

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,3 @@
-using Revise 
-import Pkg;Pkg.activate("/home/brynn/Code/TMItransient.jl")
 using TMItransient, TMI 
 using Test
 using Statistics

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -245,17 +245,35 @@ using Statistics
             end   
         end
 
-
-        τ = 0:100
-        @time D̄_long = stepresponse(TMIversion, b, γ, L, B, τ, eval_func = observe, args = (wis, γ)) #90 seconds 
-        
+        #test: is the integral of ĝ equivalent to the output of the `meanage` function? (eqtn 2 of GH 2012) 
+        τ = 0:10000 
+        @time D̄_long = stepresponse(TMIversion, b, γ, L, B, τ, eval_func = observe, args = (wis, γ)) #90 seconds for 100, 98 seconds for 2000, 106 for 10k 
+        Ḡ_long, τ = globalmean_impulseresponse(D̄_long, τ)
         meanage_obs = observe(meanage(TMIversion, Alu, γ), wis, γ)
-        vals = hcat(D̄_long...)
-
+        ḡ = hcat(Ḡ_long...)
+        #d̄ = hcat(D̄_long...)
+        @test isapprox([cumsum(ḡ[i, :] .* τ)[end] for i in 1:10], meanage_obs, atol = 10)
+        
+        #=
         using PyPlot
         figure()
-        plot(vals[1, :])
+        subplot(1,2,1)
+        [plot(d̄[i, :], label = i) for i in 1:10]
+        title("D̄")
+        legend()
+        xlabel("time [yrs]")
+        ylabel("C")
+        
+        subplot(1,2,2)
+        [plot(τ, ḡ[i, :], label = i) for i in 1:10]
+        title("Ḡ")
+        legend()
+        xlabel("time [yrs]")
+        ylabel("dC/dt")
 
+        tight_layout()
+        =#
+        
 
 
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -230,7 +230,7 @@ using Statistics
 
         #I'm pretty sure globalmean_impulseresponse is generic enough to work with any of my D̄
         #turns out it works for all of them besides the one that is Field type (number 3). We'd have to define division in order for that to work. Also looks like there's an issue with subtraction? 
-        for (i, d) in enumerate([D̄_new, D̄_old, D̄_new_allout, D̄_multiple_input, D̄_observed])
+        for (i, d) in enumerate([D̄_new, D̄_old, D̄_new_allout, D̄_observed])
             try
                 globalmean_impulseresponse(d, τ, alg = :centered)
             catch

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -30,13 +30,6 @@ using Statistics
         @test maximum(g2) ≤ 1.0
         #@test minimum(g) ≥ 0.0 # fails for Julia
 
-
-        # # get weighted interpolation indices
-        # wis= Vector{Tuple{Interpolations.WeightedAdjIndex{2, Float64}, Interpolations.WeightedAdjIndex{2, Float64}, Interpolations.WeightedAdjIndex{2, Float64}}}(undef,N)
-        # [wis[i] = interpindex(locs[i],γ) for i in 1:N]
-        # y1 = observe(g,wis,γ)
-        # y2 = observe(g2,wis,γ)
-
         y1 = observe(g,locs,γ)
         y2 = observe(g2,locs,γ)
 
@@ -106,9 +99,9 @@ using Statistics
         @time D̄_new_allout = stepresponse(TMIversion, b, γ, L, B, τ) #103s
 
         #use synthetic observations to grab some random wet points to observe 
-        N = 10
-        _, _, _, _, locs, wis = synthetic_observations(TMIversion,"PO₄",γ,N,0.1)
-        D̄_observed = stepresponse(TMIversion, b, γ, L, B, τ, eval_func = observe, args = (wis, γ)) 
+        #N = 10
+        #locs = [wetlocation(γ) for i in 1:N]
+        D̄_observed = stepresponse(TMIversion, b, γ, L, B, τ, eval_func = observe, args = (locs, γ)) 
 
         #I'm pretty sure globalmean_impulseresponse is generic enough to work with any of my D̄
         #turns out it works for all of them besides the one that is Field type (number 3). We'd have to define division in order for that to work. Also looks like there's an issue with subtraction? 
@@ -126,8 +119,9 @@ using Statistics
         τ = 0:4000 
         @time D̄_long = stepresponse(TMIversion, b, γ, L, B, τ, eval_func = observe, args = (locs, γ)) # 90 seconds for 100, 98 seconds for 2000, 106 for 10k 
         Ḡ_long, τ = globalmean_impulseresponse(D̄_long, τ)
+        # uses locs from top-level scope
         ā_obs = observe(meanage(TMIversion, Alu, γ), locs, γ)
-        println("Mean age at sites ",meanage_obs)
+        println("Mean age at sites ",ā_obs)
         ḡ = hcat(Ḡ_long...)
         #d̄ = hcat(D̄_long...)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,6 +10,11 @@ using Statistics
     #TMIversion = "modern_90x45x33_unpub12"
     
     A, Alu, γ, TMIfile, L, B = config_from_nc(TMIversion);
+
+    # compare g, g2 at N random points
+    N = 2
+    # get random locations that are wet (ocean)
+    locs = [wetlocation(γ) for i in 1:N]
     
     @testset "vintage test" begin
 
@@ -25,11 +30,6 @@ using Statistics
         @test maximum(g2) ≤ 1.0
         #@test minimum(g) ≥ 0.0 # fails for Julia
 
-        # compare g, g2 at N random points
-        N = 2
-        # get random locations that are wet (ocean)
-        locs = Vector{Tuple{Float64,Float64,Float64}}(undef,N)
-        [locs[i] = wetlocation(γ) for i in eachindex(locs)]
 
         # # get weighted interpolation indices
         # wis= Vector{Tuple{Interpolations.WeightedAdjIndex{2, Float64}, Interpolations.WeightedAdjIndex{2, Float64}, Interpolations.WeightedAdjIndex{2, Float64}}}(undef,N)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -26,18 +26,19 @@ using Statistics
         #@test minimum(g) ≥ 0.0 # fails for Julia
 
         # compare g, g2 at N random points
-
         N = 2
         # get random locations that are wet (ocean)
         locs = Vector{Tuple{Float64,Float64,Float64}}(undef,N)
         [locs[i] = wetlocation(γ) for i in eachindex(locs)]
 
-        # get weighted interpolation indices
-        wis= Vector{Tuple{Interpolations.WeightedAdjIndex{2, Float64}, Interpolations.WeightedAdjIndex{2, Float64}, Interpolations.WeightedAdjIndex{2, Float64}}}(undef,N)
-        [wis[i] = interpindex(locs[i],γ) for i in 1:N]
+        # # get weighted interpolation indices
+        # wis= Vector{Tuple{Interpolations.WeightedAdjIndex{2, Float64}, Interpolations.WeightedAdjIndex{2, Float64}, Interpolations.WeightedAdjIndex{2, Float64}}}(undef,N)
+        # [wis[i] = interpindex(locs[i],γ) for i in 1:N]
+        # y1 = observe(g,wis,γ)
+        # y2 = observe(g2,wis,γ)
 
-        y1 = observe(g,wis,γ)
-        y2 = observe(g2,wis,γ)
+        y1 = observe(g,locs,γ)
+        y2 = observe(g2,locs,γ)
 
         # relative difference between MATLAB and Julia computations
         for tt in 1:N
@@ -46,7 +47,102 @@ using Statistics
 
     end
 
-    # @testset "monotonicinterpolation" begin
+    @testset "watermass_stepresponse" begin
+        using LinearAlgebra
+
+        # read a water-mass surface patch from these choices
+        list = ("GLOBAL","ANT","SUBANT",
+                "NATL","NPAC","TROP","ARC",
+                "MED","ROSS","WED","LAB","GIN",
+                "ADEL","SUBANTATL","SUBANTPAC","SUBANTIND",
+                "TROPATL","TROPPAC","TROPIND")
+
+        # choose water mass (i.e., surface patch) of interest
+        region = list[1]
+        #tspan = (0.0, 5.0)
+        τ = 0:3
+        # replace with function call
+        # add alg=QNDF() as optional argument
+
+        @time D̄ = globalmean_stepresponse(TMIversion,region,γ,L,B,τ) # CDF
+
+        # should monotonically increase
+        @test sum(diff(D̄) .≥ 0) == length(D̄) - 1
+
+        Ḡ,tḠ = globalmean_impulseresponse(TMIversion,region,γ,L,B,τ,alg=:centered)
+        
+        # Ḡ should be non-negative
+        @test sum(Ḡ .≥ 0) == length(Ḡ)
+
+        # Ḡ should add to something less than unity
+        @test sum(Ḡ) ≤ 1.0
+
+        # compare to reading same thing from MATLAB output.
+        Δ,τmat = read_stepresponse()
+
+        # relative difference between MATLAB and Julia computations
+        for tt in 2:3
+            ϵ = 100*abs(mean(Δ[tt]) - D̄[tt])./(mean(Δ[tt]) + D̄[tt])
+            println("percent difference is ",ϵ)
+            @test ϵ < 1.0 # percent
+        end
+        
+    end
+
+    region = "GLOBAL"
+    b = TMI.surfaceregion(TMIversion, region, γ)
+
+    @testset "stepresponse" begin
+        τ = 0:2
+
+        #this should have the same result as globalmean_stepresponse 
+        @time D̄_new = stepresponse(TMIversion, b, γ, L, B, τ, eval_func = mean) #103s
+        @time D̄_old = globalmean_stepresponse(TMIversion,region,γ,L,B,τ) # CDF
+
+        #D̄[1] won't match because original method sets it to 0 and I don't 
+        @test sum(D̄_new[2:3] .== D̄_old[2:3]) == 2 #105
+
+        #get output in Field type 
+        @time D̄_new_allout = stepresponse(TMIversion, b, γ, L, B, τ) #103s
+
+        #use synthetic observations to grab some random wet points to observe 
+        N = 10
+        _, _, _, _, locs, wis = synthetic_observations(TMIversion,"PO₄",γ,N,0.1)
+        D̄_observed = stepresponse(TMIversion, b, γ, L, B, τ, eval_func = observe, args = (wis, γ)) 
+
+        #I'm pretty sure globalmean_impulseresponse is generic enough to work with any of my D̄
+        #turns out it works for all of them besides the one that is Field type (number 3). We'd have to define division in order for that to work. Also looks like there's an issue with subtraction? 
+        for (i, d) in enumerate([D̄_new, D̄_old, D̄_new_allout, D̄_observed])
+            try
+                globalmean_impulseresponse(d, τ, alg = :centered)
+            catch
+                println("impulseresponse doesn't work for D̄ number: " * string(i))
+            end   
+        end
+    end
+
+    @testset "mean age" begin
+        #test: is the integral of ĝ equivalent to the output of the `meanage` function? (eqtn 2 of GH 2012) 
+        τ = 0:4000 
+        @time D̄_long = stepresponse(TMIversion, b, γ, L, B, τ, eval_func = observe, args = (locs, γ)) # 90 seconds for 100, 98 seconds for 2000, 106 for 10k 
+        Ḡ_long, τ = globalmean_impulseresponse(D̄_long, τ)
+        ā_obs = observe(meanage(TMIversion, Alu, γ), locs, γ)
+        println("Mean age at sites ",meanage_obs)
+        ḡ = hcat(Ḡ_long...)
+        #d̄ = hcat(D̄_long...)
+
+        ā = [cumsum(ḡ[i, :] .* τ)[end] for i in 1:10]
+        #@test isapprox([cumsum(ḡ[i, :] .* τ)[end] for i in 1:10], meanage_obs, atol = 50)
+
+        atol = 10
+        denom = abs.(ā + ā_obs)./2
+        replace!(x -> x< atol ? atol : x, denom)
+        relative_error = 100*abs.(ā - ā_obs)./denom
+        @test all(relative_error .< 10) # relative error less than 10 percent?
+
+    end
+
+        # @testset "monotonicinterpolation" begin
     #     using Interpolations
     #     Δ,τ = read_stepresponse()
 
@@ -69,59 +165,7 @@ using Statistics
     #     #g = vintagedistribution(1850,2022,Δ,τ)
     # end
 
-    @testset "watermass_stepresponse" begin
-        #using Revise, TMI
-        using LinearAlgebra
-        #using OrdinaryDiffEq
-        #using Interpolations
-        #using PyPlot
-        #using NaNMath
-        #using PythonPlot
-
-        #TMIversion = "modern_90x45x33_GH10_GH12"
-        #A, Alu, γ, TMIfile, L, B = config_from_nc(TMIversion);
-
-        # read a water-mass surface patch from these choices
-        list = ("GLOBAL","ANT","SUBANT",
-                "NATL","NPAC","TROP","ARC",
-                "MED","ROSS","WED","LAB","GIN",
-                "ADEL","SUBANTATL","SUBANTPAC","SUBANTIND",
-                "TROPATL","TROPPAC","TROPIND")
-
-        # choose water mass (i.e., surface patch) of interest
-        region = list[1]
-        #tspan = (0.0, 5.0)
-        τ = 0:3
-        # replace with function call
-        # add alg=QNDF() as optional argument
-
-        @time D̄ = globalmean_stepresponse(TMIversion,region,γ,L,B,τ) # CDF
-
-        # should monotonically increase
-        @test sum(diff(D̄) .≥ 0) == length(D̄) - 1
-
-        Ḡ,tḠ = globalmean_impulseresponse(TMIversion,region,γ,L,B,τ,alg=:centered)
-        #Ḡ2,tḠ2 = globalmean_impulseresponse(TMIversion,region,γ,L,B,τ,alg=:leapfrog)
-        #Ḡ3,tḠ3 = globalmean_impulseresponse(D̄,τ,alg=:leapfrog)
-        #jldsave("Gbar_TMI_90x45x33_GH10_GH12.jld2";Ḡ,tḠ)
-        
-        # Ḡ should be non-negative
-        @test sum(Ḡ .≥ 0) == length(Ḡ)
-
-        # Ḡ should add to something less than unity
-        @test sum(Ḡ) ≤ 1.0
-
-        # compare to reading same thing from MATLAB output.
-        Δ,τmat = read_stepresponse()
-
-        # relative difference between MATLAB and Julia computations
-        for tt in 2:3
-            @test 100*abs(mean(Δ[tt]) - D̄[tt])./(mean(Δ[tt]) + D̄[tt]) < 1.0 # percent
-        end
-        
-    end
-
-    # @testset "transientsimulation" begin
+        # @testset "transientsimulation" begin
 
     #     using Interpolations, NaNMath, DifferentialEquations, LinearAlgebra, PreallocationTools, Sundials
 
@@ -208,44 +252,4 @@ using Statistics
     #     end       
     #end
 
-    @testset "stepresponse" begin
-        region = "GLOBAL"
-        b = TMI.surfaceregion(TMIversion, region, γ)
-        τ = 0:3
-
-        #this should have the same result as globalmean_stepresponse 
-        @time D̄_new = stepresponse(TMIversion, b, γ, L, B, τ, eval_func = mean) #103s
-        @time D̄_old = globalmean_stepresponse(TMIversion,region,γ,L,B,τ) # CDF
-
-        #D̄[1] won't match because original method sets it to 0 and I don't 
-        @test sum(D̄_new[2:4] .== D̄_old[2:4]) == 3#105
-
-        #get output in Field type 
-        @time D̄_new_allout = stepresponse(TMIversion, b, γ, L, B, τ) #103s
-
-        #use synthetic observations to grab some random wet points to observe 
-        N = 10
-        _, _, _, _, locs, wis = synthetic_observations(TMIversion,"PO₄",γ,N,0.1)
-        D̄_observed = stepresponse(TMIversion, b, γ, L, B, τ, eval_func = observe, args = (wis, γ)) 
-
-        #I'm pretty sure globalmean_impulseresponse is generic enough to work with any of my D̄
-        #turns out it works for all of them besides the one that is Field type (number 3). We'd have to define division in order for that to work. Also looks like there's an issue with subtraction? 
-        for (i, d) in enumerate([D̄_new, D̄_old, D̄_new_allout, D̄_observed])
-            try
-                globalmean_impulseresponse(d, τ, alg = :centered)
-            catch
-                println("impulseresponse doesn't work for D̄ number: " * string(i))
-            end   
-        end
-        
-        #test: is the integral of ĝ equivalent to the output of the `meanage` function? (eqtn 2 of GH 2012) 
-        τ = 0:10000 
-        @time D̄_long = stepresponse(TMIversion, b, γ, L, B, τ, eval_func = observe, args = (wis, γ)) #90 seconds for 100, 98 seconds for 2000, 106 for 10k 
-        Ḡ_long, τ = globalmean_impulseresponse(D̄_long, τ)
-        meanage_obs = observe(meanage(TMIversion, Alu, γ), wis, γ)
-        ḡ = hcat(Ḡ_long...)
-        #d̄ = hcat(D̄_long...)
-        @test isapprox([cumsum(ḡ[i, :] .* τ)[end] for i in 1:10], meanage_obs, atol = 10)
-    end
-    
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,3 +1,5 @@
+using Revise 
+import Pkg;Pkg.activate("/home/brynn/Code/TMItransient.jl")
 using TMItransient, TMI 
 using Test
 using Statistics
@@ -10,7 +12,7 @@ using Statistics
     #TMIversion = "modern_90x45x33_unpub12"
     
     A, Alu, γ, TMIfile, L, B = config_from_nc(TMIversion,compute_lu=false);
-
+#=
     @testset "vintage test" begin
 
         using Interpolations
@@ -207,4 +209,20 @@ using Statistics
     #         println("Varying case stable: ", stable)
     #     end       
     #end
+=#
+    @testset "stepresponse" begin
+        region = "GLOBAL"
+        b = TMI.surfaceregion(TMIversion, region, γ)
+        τ = 0:3
+
+        #this should have the same response as globalmean_stepresponse 
+        @time D̄_new = stepresponse(TMIversion, b, γ, L, B, τ, eval_func = mean) #103s
+        @time D̄_old = globalmean_stepresponse(TMIversion,region,γ,L,B,τ) # CDF
+
+        #D̄[1] won't match because original method sets it to 0 and I don't 
+        @test sum(D̄_new[2:4] .== D̄_old[2:4]) == 3#105
+        
+
+    end
+    
 end


### PR DESCRIPTION
This is my attempt at the code we discussed on Friday - I wrote a version of `globalmean_stepresponse` that takes in any type of analysis function that acts upon a `Field`, and wrote some tests to check that... 
1. The new function (called `stepresponse`) matches the output of `globalmean_stepresponse` when the provided function is `mean` 
2. The output from the `stepresponse` function can be acted upon by the `globalmean_impulseresponse`. This works if the function provided to `stepresponse` outputs a Float or a Vector (at each timestep), but does not work if the function outputs a Field because / isn't defined for a Field (also it seems like subtraction isn't working quite correctly for a Field, will write a MWE and post an issue on that when I get a chance) 
3. The integral of $\bar{G}$ is equivalent to the output of the `TMI.meanage` function 

Some things that I didn't change but I think could be changed 
1.  `globalmean_impulseresponse` could be renamed to `impulseresponse` because it's actually general enough to act upon any function (not just the global mean) 

Things that I'd like feedback on 
1. Is there a better way to define a function that takes in an arbitrary number of arguments than what I did in `stepresponse`? Right now it just takes in a Vector and unpacks it when it calls the evaluation function. 
